### PR TITLE
esm module stuff

### DIFF
--- a/lame-dimension-dialogue-tool-api/src/config/passportConfig.js
+++ b/lame-dimension-dialogue-tool-api/src/config/passportConfig.js
@@ -1,7 +1,7 @@
-import jwtStrategy from 'passport-jwt/lib/strategy';
-import extractJwt from 'passport-jwt/lib/extract_jwt';
+import jwtStrategy from 'passport-jwt/lib/strategy.js';
+import extractJwt from 'passport-jwt/lib/extract_jwt.js';
 
-import authConfig from './authConfig';
+import authConfig from './authConfig.js';
 
 export let jwtAuthStrategy = new jwtStrategy(
     {

--- a/lame-dimension-dialogue-tool-api/src/controllers/userController.js
+++ b/lame-dimension-dialogue-tool-api/src/controllers/userController.js
@@ -1,4 +1,4 @@
-import Users from '../models/user';
+import Users from '../models/user.js';
 
 export default {
     getUsers: (req, res) => {

--- a/lame-dimension-dialogue-tool-api/src/routes/authRoutes.js
+++ b/lame-dimension-dialogue-tool-api/src/routes/authRoutes.js
@@ -1,8 +1,8 @@
 import express from 'express';
 import jsonwebtoken from 'jsonwebtoken';
-import authConfig from '../config/authConfig';
+import authConfig from '../config/authConfig.js';
 
-import Users from '../models/user';
+import Users from '../models/user.js';
 const router = express.Router();
 
 router.post('/', async (req, res, next) => {

--- a/lame-dimension-dialogue-tool-api/src/routes/profileRoutes.js
+++ b/lame-dimension-dialogue-tool-api/src/routes/profileRoutes.js
@@ -1,4 +1,4 @@
-import userController from '../controllers/userController';
+import userController from '../controllers/userController.js';
 import express from 'express';
 
 const router = express.Router();

--- a/lame-dimension-dialogue-tool-api/src/routes/scriptRoutes.js
+++ b/lame-dimension-dialogue-tool-api/src/routes/scriptRoutes.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import Scripts from '../models/script';
+import Scripts from '../models/script.js';
 import { randomUUID } from 'crypto';
 const router = express.Router();
 

--- a/lame-dimension-dialogue-tool-api/src/routes/userRoutes.js
+++ b/lame-dimension-dialogue-tool-api/src/routes/userRoutes.js
@@ -1,4 +1,4 @@
-import userController from '../controllers/userController';
+import userController from '../controllers/userController.js';
 import express from 'express';
 
 const router = express.Router();

--- a/lame-dimension-dialogue-tool-api/src/server.js
+++ b/lame-dimension-dialogue-tool-api/src/server.js
@@ -3,12 +3,19 @@ import mongoose from 'mongoose';
 import cors from 'cors';
 import passport from 'passport';
 
-import scriptsRoute from './routes/scriptRoutes';
-import authRoute from './routes/authRoutes';
-import userRoute from './routes/userRoutes';
-import profileRoute from './routes/profileRoutes';
+import scriptsRoute from './routes/scriptRoutes.js';
+import authRoute from './routes/authRoutes.js';
+import userRoute from './routes/userRoutes.js';
+import profileRoute from './routes/profileRoutes.js';
 
-import { jwtAuthStrategy } from './config/passportConfig';
+import { jwtAuthStrategy } from './config/passportConfig.js';
+
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __filename = fileURLToPath(import.meta.url)
+
+const __dirname = path.dirname(__filename)
 
 let app = express();
 let port = process.env.PORT || 8080;


### PR DESCRIPTION
* include the file extension (e.g. '.js') for ALL relative imports
* change package.json "type" to "module"
* define a __dirname replacement, because otherwise:

> ReferenceError: __dirname is not defined in ES module scope.
>
> This file is being treated as an ES module because it has a '.js' file extension and '/app/package.json' contains "type": "module". To treat it as a CommonJS script, rename it to use the '.cjs' file extension.